### PR TITLE
fixed issue 56

### DIFF
--- a/game/dota_addons/samplerts/scripts/vscripts/buildinghelper.lua
+++ b/game/dota_addons/samplerts/scripts/vscripts/buildinghelper.lua
@@ -151,6 +151,8 @@ function BuildingHelper:AddBuilding(keys)
 
     -- Make a model dummy to pass it to panorama
     player.activeBuildingTable.mgd = CreateUnitByName(unitName, OutOfWorldVector, false, nil, nil, builder:GetTeam())
+    player.activeBuildingTable.mgd:SetDayTimeVisionRange(0)
+    player.activeBuildingTable.mgd:SetNightTimeVisionRange(0)
 
     -- Adjust the Model Orientation
     local yaw = buildingTable:GetVal("ModelRotation", "float")
@@ -938,7 +940,9 @@ function BuildingHelper:AddToQueue( builder, location, bQueued )
 
     -- Create model ghost dummy out of the map, then make pretty particles
     local mgd = CreateUnitByName(building, OutOfWorldVector, false, nil, nil, builder:GetTeam())
-
+    mgd:SetDayTimeVisionRange(0)
+    mgd:SetNightTimeVisionRange(0)
+    
     local modelParticle = ParticleManager:CreateParticleForPlayer("particles/buildinghelper/ghost_model.vpcf", PATTACH_ABSORIGIN, mgd, player)
     ParticleManager:SetParticleControl(modelParticle, 0, location)
     ParticleManager:SetParticleControlEnt(modelParticle, 1, mgd, 1, "follow_origin", mgd:GetAbsOrigin(), true) -- Model attach          


### PR DESCRIPTION
Made the quick changes to the library so that the building dummy will no longer provide permanent vision in the top right corner of the map, fixing a problem (Issue #56) users may encounter if the entire map needs to be used. It does still however flash vision there for a frame, meaning that more work needs to be done on top of the fix.