### PR TITLE
Improved #56 fix

### DIFF
--- a/game/dota_addons/samplerts/scripts/vscripts/buildinghelper.lua
+++ b/game/dota_addons/samplerts/scripts/vscripts/buildinghelper.lua
@@ -419,10 +419,14 @@ function BuildingHelper:StartBuilding( keys )
     building.blockers = gridNavBlockers
     building.buildingTable = buildingTable
     building.state = "building"
-    building:SetAbsOrigin(location)
-            
-    -- Remove ghost model
-    UTIL_Remove(buildingTable.mgd)
+    
+    Timers:CreateTimer(
+        function() 
+            building:SetAbsOrigin(location)
+            buildingTable.mgd:SetDayTimeVisionRange(0) -- Prevent game from forgetting that this unit should not have vision
+            buildingTable.mgd:SetNightTimeVisionRange(0) -- So user does not get vision where the dummy is off the map.
+            UTIL_Remove(buildingTable.mgd) -- Remove ghost model
+        end)
 
 
     -- Adjust the Model Orientation

--- a/game/dota_addons/samplerts/scripts/vscripts/buildinghelper.lua
+++ b/game/dota_addons/samplerts/scripts/vscripts/buildinghelper.lua
@@ -151,6 +151,8 @@ function BuildingHelper:AddBuilding(keys)
 
     -- Make a model dummy to pass it to panorama
     player.activeBuildingTable.mgd = CreateUnitByName(unitName, OutOfWorldVector, false, nil, nil, builder:GetTeam())
+    player.activeBuildingTable.mgd:SetDayTimeVisionRange(0)
+    player.activeBuildingTable.mgd:SetNightTimeVisionRange(0)
 
     -- Adjust the Model Orientation
     local yaw = buildingTable:GetVal("ModelRotation", "float")
@@ -938,7 +940,9 @@ function BuildingHelper:AddToQueue( builder, location, bQueued )
 
     -- Create model ghost dummy out of the map, then make pretty particles
     local mgd = CreateUnitByName(building, OutOfWorldVector, false, nil, nil, builder:GetTeam())
-
+    mgd:SetDayTimeVisionRange(0)
+    mgd:SetNightTimeVisionRange(0)
+    
     local modelParticle = ParticleManager:CreateParticleForPlayer("particles/buildinghelper/ghost_model.vpcf", PATTACH_ABSORIGIN, mgd, player)
     ParticleManager:SetParticleControl(modelParticle, 0, location)
     ParticleManager:SetParticleControlEnt(modelParticle, 1, mgd, 1, "follow_origin", mgd:GetAbsOrigin(), true) -- Model attach          

--- a/game/dota_addons/samplerts/scripts/vscripts/buildinghelper.lua
+++ b/game/dota_addons/samplerts/scripts/vscripts/buildinghelper.lua
@@ -419,14 +419,11 @@ function BuildingHelper:StartBuilding( keys )
     building.blockers = gridNavBlockers
     building.buildingTable = buildingTable
     building.state = "building"
-
-    Timers:CreateTimer(
-        function() 
-            building:SetAbsOrigin(location)
+    building:SetAbsOrigin(location)
             
-            -- Remove ghost model
-            UTIL_Remove(buildingTable.mgd)
-        end)
+    -- Remove ghost model
+    UTIL_Remove(buildingTable.mgd)
+
 
     -- Adjust the Model Orientation
     local yaw = buildingTable:GetVal("ModelRotation", "float")


### PR DESCRIPTION
Removed the timer that is called when the building is placed, thereby no longer delaying removing the ghost for a second, fixing the minor flash of vision when the building is placed from the earlier fork. Should no longer grant any vision to the player in the top right hand corner of the map.